### PR TITLE
Fix sdlConverter to export as commonjs

### DIFF
--- a/src/sdlConverter.ts
+++ b/src/sdlConverter.ts
@@ -392,7 +392,7 @@ export class SDLConverter {
 
   printExports() {
     if (this.commonjs === null || this.exports.size === 0) {
-      return [];
+      return "";
     }
     const exports = Array.from(this.exports);
     if (this.commonjs) {

--- a/src/sdlConverter.ts
+++ b/src/sdlConverter.ts
@@ -56,7 +56,7 @@ export class SDLConverter {
     protected commonjs: null | boolean = false,
     protected json: JSON = JSON
   ) {
-    this.export = "const ";
+    this.export = commonjs === null || commonjs ? "const " : "export const ";
     this.schema = buildSchema(sdl);
     this.groupedTypes = groupTypes(this.schema);
   }
@@ -391,15 +391,11 @@ export class SDLConverter {
   }
 
   printExports() {
-    if (this.commonjs === null || this.exports.size === 0) {
+    if (!this.commonjs || this.exports.size === 0) {
       return "";
     }
     const exports = Array.from(this.exports);
-    if (this.commonjs) {
-      return this.printBlock(exports.map((exp) => `exports.${exp} = ${exp};`));
-    } else {
-      return this.printBlock([`export { ${exports.join(", ")} };`]);
-    }
+    return this.printBlock(exports.map((exp) => `exports.${exp} = ${exp};`));
   }
 
   maybeAsNexusType(type: GraphQLScalarType) {

--- a/tests/sdlConverter.spec.ts
+++ b/tests/sdlConverter.spec.ts
@@ -7,7 +7,7 @@ describe("SDLConverter", () => {
   test("printObjectTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printObjectTypes())
       .toMatchInlineSnapshot(`
-"export const Mutation = objectType({
+"const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
     t.field(\\"createPost\\", {
@@ -27,7 +27,7 @@ describe("SDLConverter", () => {
     })
   }
 })
-export const Post = objectType({
+const Post = objectType({
   name: \\"Post\\",
   definition(t) {
     t.implements(Node)
@@ -40,7 +40,7 @@ export const Post = objectType({
     })
   }
 })
-export const Query = objectType({
+const Query = objectType({
   name: \\"Query\\",
   definition(t) {
     t.field(\\"user\\", { type: User })
@@ -55,7 +55,7 @@ export const Query = objectType({
     })
   }
 })
-export const User = objectType({
+const User = objectType({
   name: \\"User\\",
   definition(t) {
     t.implements(Node)
@@ -85,11 +85,11 @@ export const User = objectType({
   test("printEnumTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printEnumTypes())
       .toMatchInlineSnapshot(`
-"export const OrderEnum = enumType({
+"const OrderEnum = enumType({
   name: \\"OrderEnum\\",
   members: [\\"ASC\\",\\"DESC\\"],
 });
-export const SomeEnum = enumType({
+const SomeEnum = enumType({
   name: \\"SomeEnum\\",
   members: [\\"A\\",\\"B\\"],
 });"
@@ -99,7 +99,7 @@ export const SomeEnum = enumType({
   test("printScalarTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printScalarTypes())
       .toMatchInlineSnapshot(`
-"export const UUID = scalarType({
+"const UUID = scalarType({
   name: \\"UUID\\",
   asNexusMethod: \\"uuid\\",
   serialize() { /* Todo */ },
@@ -112,7 +112,7 @@ export const SomeEnum = enumType({
   test("printInterfaceTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printInterfaceTypes())
       .toMatchInlineSnapshot(`
-"export const Node = interfaceType({
+"const Node = interfaceType({
   name: \\"Node\\",
   description: \\"This is a description of a Node\\",
   definition(t) {
@@ -128,7 +128,7 @@ test("convertSDL", () => {
   expect(convertSDL(EXAMPLE_SDL)).toMatchInlineSnapshot(`
 "import { objectType, arg, uuidArg, stringArg, interfaceType, inputObjectType, unionType, enumType, scalarType } from 'nexus';
 
-export const Mutation = objectType({
+const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
     t.field(\\"createPost\\", {
@@ -148,7 +148,7 @@ export const Mutation = objectType({
     })
   }
 })
-export const Post = objectType({
+const Post = objectType({
   name: \\"Post\\",
   definition(t) {
     t.implements(Node)
@@ -161,7 +161,7 @@ export const Post = objectType({
     })
   }
 })
-export const Query = objectType({
+const Query = objectType({
   name: \\"Query\\",
   definition(t) {
     t.field(\\"user\\", { type: User })
@@ -176,7 +176,7 @@ export const Query = objectType({
     })
   }
 })
-export const User = objectType({
+const User = objectType({
   name: \\"User\\",
   definition(t) {
     t.implements(Node)
@@ -201,7 +201,7 @@ export const User = objectType({
   }
 })
 
-export const Node = interfaceType({
+const Node = interfaceType({
   name: \\"Node\\",
   description: \\"This is a description of a Node\\",
   definition(t) {
@@ -210,7 +210,7 @@ export const Node = interfaceType({
   }
 });
 
-export const CreatePostInput = inputObjectType({
+const CreatePostInput = inputObjectType({
   name: \\"CreatePostInput\\",
   definition(t) {
     t.string(\\"name\\", { required: true })
@@ -221,7 +221,7 @@ export const CreatePostInput = inputObjectType({
     })
   }
 });
-export const PostFilters = inputObjectType({
+const PostFilters = inputObjectType({
   name: \\"PostFilters\\",
   definition(t) {
     t.field(\\"order\\", {
@@ -232,28 +232,30 @@ export const PostFilters = inputObjectType({
   }
 });
 
-export const ExampleUnion = unionType({
+const ExampleUnion = unionType({
   name: \\"ExampleUnion\\",
   definition(t) {
     t.members(Post, User)
   }
 });
 
-export const OrderEnum = enumType({
+const OrderEnum = enumType({
   name: \\"OrderEnum\\",
   members: [\\"ASC\\",\\"DESC\\"],
 });
-export const SomeEnum = enumType({
+const SomeEnum = enumType({
   name: \\"SomeEnum\\",
   members: [\\"A\\",\\"B\\"],
 });
 
-export const UUID = scalarType({
+const UUID = scalarType({
   name: \\"UUID\\",
   asNexusMethod: \\"uuid\\",
   serialize() { /* Todo */ },
   parseValue() { /* Todo */ },
   parseLiteral() { /* Todo */ }
-});"
+});
+
+export { Mutation, Post, Query, User, Node, CreatePostInput, PostFilters, ExampleUnion, OrderEnum, SomeEnum, UUID };"
 `);
 });

--- a/tests/sdlConverter.spec.ts
+++ b/tests/sdlConverter.spec.ts
@@ -259,3 +259,149 @@ const UUID = scalarType({
 export { Mutation, Post, Query, User, Node, CreatePostInput, PostFilters, ExampleUnion, OrderEnum, SomeEnum, UUID };"
 `);
 });
+
+test("convertSDL as commonjs", () => {
+  expect(convertSDL(EXAMPLE_SDL, true)).toMatchInlineSnapshot(`
+"const { objectType, arg, uuidArg, stringArg, interfaceType, inputObjectType, unionType, enumType, scalarType } = require('nexus');
+
+const Mutation = objectType({
+  name: \\"Mutation\\",
+  definition(t) {
+    t.field(\\"createPost\\", {
+      type: Post,
+      args: {
+        input: arg({
+          type: CreatePostInput,
+          required: true
+        }),
+      },
+    })
+    t.field(\\"registerClick\\", {
+      type: Query,
+      args: {
+        uuid: uuidArg(),
+      },
+    })
+  }
+})
+const Post = objectType({
+  name: \\"Post\\",
+  definition(t) {
+    t.implements(Node)
+    t.uuid(\\"uuid\\")
+    t.field(\\"author\\", { type: User })
+    t.float(\\"geo\\", { list: [true, true] })
+    t.float(\\"messyGeo\\", {
+      list: [true, false],
+      nullable: true,
+    })
+  }
+})
+const Query = objectType({
+  name: \\"Query\\",
+  definition(t) {
+    t.field(\\"user\\", { type: User })
+    t.list.field(\\"posts\\", {
+      type: Post,
+      args: {
+        filters: arg({
+          type: PostFilters,
+          required: true
+        }),
+      },
+    })
+  }
+})
+const User = objectType({
+  name: \\"User\\",
+  definition(t) {
+    t.implements(Node)
+    t.string(\\"name\\", {
+      description: \\"This is a description of a name\\",
+      args: {
+        prefix: stringArg({ description: \\"And a description of an arg\\" }),
+      },
+    })
+    t.string(\\"email\\")
+    t.string(\\"phone\\", { nullable: true })
+    t.list.field(\\"posts\\", {
+      type: Post,
+      args: {
+        filters: arg({ type: PostFilters }),
+      },
+    })
+    t.field(\\"outEnum\\", {
+      type: SomeEnum,
+      nullable: true,
+    })
+  }
+})
+
+const Node = interfaceType({
+  name: \\"Node\\",
+  description: \\"This is a description of a Node\\",
+  definition(t) {
+    t.id(\\"id\\")
+    t.resolveType(() => null)
+  }
+});
+
+const CreatePostInput = inputObjectType({
+  name: \\"CreatePostInput\\",
+  definition(t) {
+    t.string(\\"name\\", { required: true })
+    t.id(\\"author\\", { required: true })
+    t.float(\\"geo\\", {
+      list: [false, true],
+      required: true,
+    })
+  }
+});
+const PostFilters = inputObjectType({
+  name: \\"PostFilters\\",
+  definition(t) {
+    t.field(\\"order\\", {
+      type: OrderEnum,
+      required: true,
+    })
+    t.string(\\"search\\")
+  }
+});
+
+const ExampleUnion = unionType({
+  name: \\"ExampleUnion\\",
+  definition(t) {
+    t.members(Post, User)
+  }
+});
+
+const OrderEnum = enumType({
+  name: \\"OrderEnum\\",
+  members: [\\"ASC\\",\\"DESC\\"],
+});
+const SomeEnum = enumType({
+  name: \\"SomeEnum\\",
+  members: [\\"A\\",\\"B\\"],
+});
+
+const UUID = scalarType({
+  name: \\"UUID\\",
+  asNexusMethod: \\"uuid\\",
+  serialize() { /* Todo */ },
+  parseValue() { /* Todo */ },
+  parseLiteral() { /* Todo */ }
+});
+
+exports.Mutation = Mutation;
+exports.Post = Post;
+exports.Query = Query;
+exports.User = User;
+exports.Node = Node;
+exports.CreatePostInput = CreatePostInput;
+exports.PostFilters = PostFilters;
+exports.ExampleUnion = ExampleUnion;
+exports.OrderEnum = OrderEnum;
+exports.SomeEnum = SomeEnum;
+exports.UUID = UUID;"
+`);
+});

--- a/tests/sdlConverter.spec.ts
+++ b/tests/sdlConverter.spec.ts
@@ -7,7 +7,7 @@ describe("SDLConverter", () => {
   test("printObjectTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printObjectTypes())
       .toMatchInlineSnapshot(`
-"const Mutation = objectType({
+"export const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
     t.field(\\"createPost\\", {
@@ -27,7 +27,7 @@ describe("SDLConverter", () => {
     })
   }
 })
-const Post = objectType({
+export const Post = objectType({
   name: \\"Post\\",
   definition(t) {
     t.implements(Node)
@@ -40,7 +40,7 @@ const Post = objectType({
     })
   }
 })
-const Query = objectType({
+export const Query = objectType({
   name: \\"Query\\",
   definition(t) {
     t.field(\\"user\\", { type: User })
@@ -55,7 +55,7 @@ const Query = objectType({
     })
   }
 })
-const User = objectType({
+export const User = objectType({
   name: \\"User\\",
   definition(t) {
     t.implements(Node)
@@ -85,11 +85,11 @@ const User = objectType({
   test("printEnumTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printEnumTypes())
       .toMatchInlineSnapshot(`
-"const OrderEnum = enumType({
+"export const OrderEnum = enumType({
   name: \\"OrderEnum\\",
   members: [\\"ASC\\",\\"DESC\\"],
 });
-const SomeEnum = enumType({
+export const SomeEnum = enumType({
   name: \\"SomeEnum\\",
   members: [\\"A\\",\\"B\\"],
 });"
@@ -99,7 +99,7 @@ const SomeEnum = enumType({
   test("printScalarTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printScalarTypes())
       .toMatchInlineSnapshot(`
-"const UUID = scalarType({
+"export const UUID = scalarType({
   name: \\"UUID\\",
   asNexusMethod: \\"uuid\\",
   serialize() { /* Todo */ },
@@ -112,7 +112,7 @@ const SomeEnum = enumType({
   test("printInterfaceTypes", () => {
     expect(new SDLConverter(EXAMPLE_SDL).printInterfaceTypes())
       .toMatchInlineSnapshot(`
-"const Node = interfaceType({
+"export const Node = interfaceType({
   name: \\"Node\\",
   description: \\"This is a description of a Node\\",
   definition(t) {
@@ -128,7 +128,7 @@ test("convertSDL", () => {
   expect(convertSDL(EXAMPLE_SDL)).toMatchInlineSnapshot(`
 "import { objectType, arg, uuidArg, stringArg, interfaceType, inputObjectType, unionType, enumType, scalarType } from 'nexus';
 
-const Mutation = objectType({
+export const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
     t.field(\\"createPost\\", {
@@ -148,7 +148,7 @@ const Mutation = objectType({
     })
   }
 })
-const Post = objectType({
+export const Post = objectType({
   name: \\"Post\\",
   definition(t) {
     t.implements(Node)
@@ -161,7 +161,7 @@ const Post = objectType({
     })
   }
 })
-const Query = objectType({
+export const Query = objectType({
   name: \\"Query\\",
   definition(t) {
     t.field(\\"user\\", { type: User })
@@ -176,7 +176,7 @@ const Query = objectType({
     })
   }
 })
-const User = objectType({
+export const User = objectType({
   name: \\"User\\",
   definition(t) {
     t.implements(Node)
@@ -201,7 +201,7 @@ const User = objectType({
   }
 })
 
-const Node = interfaceType({
+export const Node = interfaceType({
   name: \\"Node\\",
   description: \\"This is a description of a Node\\",
   definition(t) {
@@ -210,7 +210,7 @@ const Node = interfaceType({
   }
 });
 
-const CreatePostInput = inputObjectType({
+export const CreatePostInput = inputObjectType({
   name: \\"CreatePostInput\\",
   definition(t) {
     t.string(\\"name\\", { required: true })
@@ -221,7 +221,7 @@ const CreatePostInput = inputObjectType({
     })
   }
 });
-const PostFilters = inputObjectType({
+export const PostFilters = inputObjectType({
   name: \\"PostFilters\\",
   definition(t) {
     t.field(\\"order\\", {
@@ -232,31 +232,29 @@ const PostFilters = inputObjectType({
   }
 });
 
-const ExampleUnion = unionType({
+export const ExampleUnion = unionType({
   name: \\"ExampleUnion\\",
   definition(t) {
     t.members(Post, User)
   }
 });
 
-const OrderEnum = enumType({
+export const OrderEnum = enumType({
   name: \\"OrderEnum\\",
   members: [\\"ASC\\",\\"DESC\\"],
 });
-const SomeEnum = enumType({
+export const SomeEnum = enumType({
   name: \\"SomeEnum\\",
   members: [\\"A\\",\\"B\\"],
 });
 
-const UUID = scalarType({
+export const UUID = scalarType({
   name: \\"UUID\\",
   asNexusMethod: \\"uuid\\",
   serialize() { /* Todo */ },
   parseValue() { /* Todo */ },
   parseLiteral() { /* Todo */ }
-});
-
-export { Mutation, Post, Query, User, Node, CreatePostInput, PostFilters, ExampleUnion, OrderEnum, SomeEnum, UUID };"
+});"
 `);
 });
 


### PR DESCRIPTION
Exported files by sdlConverter with `commonjs: true` option cause ReferenceError like below.

```
 $  yarn start
yarn run v1.10.1
$ node lib/index.js
/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/generated/project_server-types.js:40
    t.list.field("staffings", { type: Staffing })
                                      ^

ReferenceError: Staffing is not defined
    at Object.definition (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/generated/project_server-types.js:40:39)
    at SchemaBuilder.buildObjectType (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:159:16)
    at SchemaBuilder.getOrBuildType (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:513:29)
    at /Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:117:45
    at Array.forEach (<anonymous>)
    at SchemaBuilder.getFinalTypeMap (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:108:42)
    at buildTypes (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:565:20)
    at makeSchemaInternal (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:593:19)
    at Object.makeSchema (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/node_modules/nexus/dist/builder.js:621:18)
    at Object.<anonymous> (/Users/moriwakikento/.ghq/github.com/KentoMoriwaki/grgr/lib/index.js:7:24)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The export file is like this. `type: Staffing` cannot refer `exports.Staffing`. 

```
exports.Project = objectType({
  name: "Project",
  definition(t) {
    t.int("id", { nullable: true })
    t.string("title", { nullable: true })
    t.list.field("staffings", { type: Staffing })
  }
})
exports.Staffing = objectType({
  name: "Staffing",
  definition(t) {
    t.int("id", { nullable: true })
    t.string("introduction", { nullable: true })
    t.int("staffId", { nullable: true })
  }
})
```

So I changed to export all at the bottom of codes.

```
const Project = objectType({
  name: "Project",
  definition(t) {
    t.int("id", { nullable: true })
    t.string("title", { nullable: true })
    t.list.field("staffings", { type: Staffing })
  }
})
const Staffing = objectType({
  name: "Staffing",
  definition(t) {
    t.int("id", { nullable: true })
    t.string("introduction", { nullable: true })
    t.int("staffId", { nullable: true })
  }
})

exports.Project = Project;
exports.Staffing = Staffing;
```

