### PR TITLE
Fix docs for shouldGenerateArtifacts default

### DIFF
--- a/docs/api-makeSchema.md
+++ b/docs/api-makeSchema.md
@@ -41,7 +41,7 @@ interface SchemaConfig {
     | false;
   /**
    * Whether the schema & types are generated when the server
-   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV !== "development"
+   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV === "development"
    */
   shouldGenerateArtifacts?: boolean;
   /**

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -118,7 +118,7 @@ export interface BuilderConfig {
     | false;
   /**
    * Whether the schema & types are generated when the server
-   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV !== "development"
+   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV === "development"
    */
   shouldGenerateArtifacts?: boolean;
   /**


### PR DESCRIPTION
Hello,

Thank you for the great work with Nexus!

I have noticed that the docs state the opposite default value for `shouldGenerateArtifacts` as it is defined in the code:
https://github.com/prisma/nexus/blob/a6156ee8f46b2e525c24b849934a51e315f4ece1/src/builder.ts#L1012-L1014