### PR TITLE
fix: generate schema and types only if not in production

### DIFF
--- a/docs/api-makeSchema.md
+++ b/docs/api-makeSchema.md
@@ -41,7 +41,7 @@ interface SchemaConfig {
     | false;
   /**
    * Whether the schema & types are generated when the server
-   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV === "development"
+   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV !== "production"
    */
   shouldGenerateArtifacts?: boolean;
   /**

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -129,7 +129,7 @@ export interface BuilderConfig {
     | false;
   /**
    * Whether the schema & types are generated when the server
-   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV === "development"
+   * starts. Default is !process.env.NODE_ENV || process.env.NODE_ENV !== "production"
    */
   shouldGenerateArtifacts?: boolean;
   /**
@@ -1082,11 +1082,11 @@ export function makeSchemaInternal(
 export function makeSchema(options: SchemaConfig): GraphQLSchema {
   const { schema } = makeSchemaInternal(options);
 
-  // Only in development envs do we want to worry about regenerating the
+  // Only if not in production we want to worry about regenerating the
   // schema definition and/or generated types.
   const {
     shouldGenerateArtifacts = Boolean(
-      !process.env.NODE_ENV || process.env.NODE_ENV === "development"
+      !process.env.NODE_ENV || process.env.NODE_ENV !== "production"
     ),
   } = options;
 


### PR DESCRIPTION
The documentation states that the schema and types gets generated if not in production environment, but the default in the source code was `process.env.NODE_ENV === "development"`.

I encountered this because i was using it with `process.env.NODE_ENV === "test"` in testing mode and no schema and types was generated.