### PR TITLE
Update playground url

### DIFF
--- a/docs/library-authors.md
+++ b/docs/library-authors.md
@@ -17,7 +17,7 @@ export const UserConnectionTypes = connectionType("User");
 Where `connectionType` is really just a wrapper creating two `objectTypes`:
 
 ```ts
-import { core } from './nexus';
+import { core } from 'nexus';
 
 export function connectionType(type: core.AllOutputTypes) {
   const Connection = objectType({

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -35,7 +35,7 @@ class Footer extends React.Component {
             <h5>Docs</h5>
             <a href={this.docUrl("getting-started")}>Getting Started</a>
             <a href={this.docUrl("api-core-concepts")}>API Reference</a>
-            <a href="playground">Playground</a>
+            <a href={this.pageUrl("playground")}>Playground</a>
           </div>
           <div>
             <h5>More</h5>


### PR DESCRIPTION
+ Update playground url to prevent that if you're on `docs` and click on `playground` the url is going to be `https://nexus.js.org/docs/playground`

+ Replace `./nexus` for `nexus` to follow the same order on all the docs.