### PR TITLE
Extract reusable type for the "type" option

### DIFF
--- a/src/definitions/args.ts
+++ b/src/definitions/args.ts
@@ -32,17 +32,17 @@ export interface ScalarArgConfig<T> extends CommonArgConfig {
    */
   default?: T;
 }
-
+export type NexusArgConfigType<T> = 
+    | T
+    | AllNexusInputTypeDefs<T>
+    | NexusWrappedType<AllNexusInputTypeDefs<T>>;
 export interface NexusArgConfig<T extends GetGen<"allInputTypes", string>>
   extends CommonArgConfig {
   /**
    * The type of the argument, either the string name of the type,
    * or the concrete Nexus type definition
    */
-  type:
-    | T
-    | AllNexusInputTypeDefs<T>
-    | NexusWrappedType<AllNexusInputTypeDefs<T>>;
+  type: NexusArgConfigType<T>
   /**
    * Configure the default for the object
    */
@@ -68,7 +68,7 @@ withNexusSymbol(NexusArgDef, NexusTypes.Arg);
  * @see https://graphql.github.io/learn/schema/#arguments
  */
 export function arg<T extends GetGen<"allInputTypes", string>>(
-  options: { type: T | AllNexusInputTypeDefs<T> } & NexusArgConfig<T>
+  options: { type: NexusArgConfigType<T> } & NexusArgConfig<T>
 ) {
   if (!options.type) {
     throw new Error('You must provide a "type" for the arg()');


### PR DESCRIPTION
This allows you to pass a `NexusWrappedType` instance as an argument for type when using `arg({ type: ... })` utility to define an argument for a type.

Ex: 

```
import MyType from './MyType'

const MyOtherType = queryField('name', {
  args: { myType: arg({ type: MyType }) } 
})
```

The feature actually works as is, the type is incorrect though.