### PR TITLE
Fix import path generation on Windows

### DIFF
--- a/src/typegenAutoConfig.ts
+++ b/src/typegenAutoConfig.ts
@@ -321,8 +321,9 @@ export function typegenAutoConfig(options: TypegenAutoConfigOptions) {
 
     Object.keys(importsMap).sort().forEach((alias) => {
       const [importPath, glob] = importsMap[alias];
+      const safeImportPath = importPath.replace(/\\+/g, '/');
       imports.push(
-        `import ${glob ? "* as " : ""}${alias} from "${importPath}"`
+        `import ${glob ? "* as " : ""}${alias} from "${safeImportPath}"`
       );
     });
 


### PR DESCRIPTION
The `typeGenAutoConfig` currently generates invalid import paths containing non-escaped backslashes if run on Windows.

This PR fixes that by using a regex that replaces every backslash with a forward slash.

Fix #41 