### PR TITLE
Fix #89, SDL converter & list w/ nested varying null items

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@types/graphql": "^14.0.5",
+    "@types/graphql": "^14.0.7",
     "@types/jest": "^23.3.7",
     "@types/node": "^10.12.2",
     "@types/prettier": "^1.15.2",

--- a/src/sdlConverter.ts
+++ b/src/sdlConverter.ts
@@ -140,7 +140,7 @@ export class SDLConverter {
     field: GraphQLField<any, any> | GraphQLInputField
   ) {
     const { list, type: fieldType, isNonNull } = unwrapType(field.type);
-    const prefix = list.length === 1 ? `t.list.` : `t.`;
+    const prefix = list.length === 1 && list[0] === true ? `t.list.` : `t.`;
     return `    ${prefix}${this.printFieldMethod(
       source,
       field,
@@ -170,7 +170,7 @@ export class SDLConverter {
     if ("deprecationReason" in field && field.deprecationReason) {
       objectMeta.deprecation = field.deprecationReason;
     }
-    if (list.length > 1) {
+    if (list.length > 1 || list[0] === false) {
       objectMeta.list = list;
     }
     if (!isNonNull && source === "output") {
@@ -249,7 +249,9 @@ export class SDLConverter {
     }
     if (list.length) {
       metaToAdd.push(
-        list.length === 1 ? `list: true` : `list: [${list.join(", ")}]`
+        list.length === 1 && list[0] === true
+          ? `list: true`
+          : `list: [${list.join(", ")}]`
       );
     }
     if (arg.defaultValue !== undefined) {

--- a/tests/_sdl.ts
+++ b/tests/_sdl.ts
@@ -63,6 +63,7 @@ input CreatePostInput {
 }
 
 type Mutation {
+  someList(items: [String]!): [String]!
   createPost(input: CreatePostInput!): Post!
   registerClick(uuid: UUID): Query!
 }

--- a/tests/sdlConverter.spec.ts
+++ b/tests/sdlConverter.spec.ts
@@ -10,6 +10,15 @@ describe("SDLConverter", () => {
 "export const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
+    t.string(\\"someList\\", {
+      list: [false],
+      args: {
+        items: stringArg({
+          list: [false],
+          required: true
+        }),
+      },
+    })
     t.field(\\"createPost\\", {
       type: Post,
       args: {
@@ -127,11 +136,20 @@ export const SomeEnum = enumType({
 
 test("convertSDL", () => {
   expect(convertSDL(EXAMPLE_SDL)).toMatchInlineSnapshot(`
-"import { objectType, arg, uuidArg, stringArg, interfaceType, inputObjectType, unionType, enumType, scalarType } from 'nexus';
+"import { objectType, stringArg, arg, uuidArg, interfaceType, inputObjectType, unionType, enumType, scalarType } from 'nexus';
 
 export const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
+    t.string(\\"someList\\", {
+      list: [false],
+      args: {
+        items: stringArg({
+          list: [false],
+          required: true
+        }),
+      },
+    })
     t.field(\\"createPost\\", {
       type: Post,
       args: {
@@ -262,11 +280,20 @@ export const UUID = scalarType({
 
 test("convertSDL as commonjs", () => {
   expect(convertSDL(EXAMPLE_SDL, true)).toMatchInlineSnapshot(`
-"const { objectType, arg, uuidArg, stringArg, interfaceType, inputObjectType, unionType, enumType, scalarType } = require('nexus');
+"const { objectType, stringArg, arg, uuidArg, interfaceType, inputObjectType, unionType, enumType, scalarType } = require('nexus');
 
 const Mutation = objectType({
   name: \\"Mutation\\",
   definition(t) {
+    t.string(\\"someList\\", {
+      list: [false],
+      args: {
+        items: stringArg({
+          list: [false],
+          required: true
+        }),
+      },
+    })
     t.field(\\"createPost\\", {
       type: Post,
       args: {

--- a/tests/typegen.spec.ts
+++ b/tests/typegen.spec.ts
@@ -86,6 +86,9 @@ describe("typegen", () => {
     registerClick: { // args
       uuid?: string | null; // UUID
     }
+    someList: { // args
+      items: Array<string | null>; // [String]!
+    }
   }
   Query: {
     posts: { // args
@@ -193,6 +196,7 @@ describe("typegen", () => {
   Mutation: { // field return type
     createPost: NexusGenRootTypes['Post']; // Post!
     registerClick: NexusGenRootTypes['Query']; // Query!
+    someList: Array<string | null>; // [String]!
   }
   Post: { // field return type
     author: NexusGenRootTypes['User']; // User!
@@ -291,6 +295,7 @@ export interface NexusGenFieldTypes {
   Mutation: { // field return type
     createPost: NexusGenRootTypes['Post']; // Post!
     registerClick: NexusGenRootTypes['Query']; // Query!
+    someList: Array<string | null>; // [String]!
   }
   Post: { // field return type
     author: NexusGenRootTypes['User']; // User!
@@ -324,6 +329,9 @@ export interface NexusGenArgTypes {
     }
     registerClick: { // args
       uuid?: string | null; // UUID
+    }
+    someList: { // args
+      items: Array<string | null>; // [String]!
     }
   }
   Query: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@types/graphql@^14.0.5":
-  version "14.0.5"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.5.tgz#e696292fd2d77dc168b5b791710f83463aa39abd"
-  integrity sha512-bwGYLE0SRy5ZraC91dqI2bxbspfm10kyJ2Yjuvk4OjdGznh7fkoWW+xXZHfFydJaqu9syZi099cpiZw3GlPDiA==
+"@types/graphql@^14.0.7":
+  version "14.0.7"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
+  integrity sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==
 
 "@types/jest@^23.3.7":
   version "23.3.10"
@@ -744,6 +744,8 @@ cssstyle@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   integrity sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==
+  dependencies:
+    cssom "0.3.x"
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
This fixes the SDL converter for lists with a depth of 1 with nullable members. 

Need to add docs for this, but `list: boolean[]` is the syntax for lists with configurable depth/nullability.

These two are equivalent:
```ts
t.string('someField', { list: true }) // someField: [String!]!
t.list.string('someField') // someField: [String!]! 
```

When you have nullable items:

```ts
t.string('someField', { list: [false] }) // someField: [String]!
```
For nested lists:

```ts
t.string('someField', { list: [false, true] }) // someField: [[String]!]!
t.string('someField', { list: [true, true] }) // someField: [[String!]!]!
```
