### PR TITLE
[docs]: fix definition methods typo on prismaObjectType()

### DIFF
--- a/docs/database-access-with-prisma.md
+++ b/docs/database-access-with-prisma.md
@@ -324,11 +324,11 @@ import datamodelInfo from './generated/nexus-prisma'
 
 const Query = prismaObjectType({
   name: 'Query',
-  definition(t) => t.prismaFields(['*'])
+  definition: (t) => t.prismaFields(['*'])
 })
 const Mutation = prismaObjectType({
   name: 'Mutation',
-  definition(t) => t.prismaFields(['*'])
+  definition: (t) => t.prismaFields(['*'])
 })
 
 const schema = makePrismaSchema({


### PR DESCRIPTION
Hello there :wave:,

After following the getting started on Nexus with Prisma, i found a little typo [here](https://nexus.js.org/docs/database-access-with-prisma#expose-full-crud-graphql-api).