### PR TITLE
Add promise support to subscriptions

### DIFF
--- a/src/definitions/subscriptionField.ts
+++ b/src/definitions/subscriptionField.ts
@@ -26,7 +26,7 @@ export interface SubscribeFieldConfig<
     args: ArgsValue<TypeName, FieldName>,
     ctx: GetGen<"context">,
     info: GraphQLResolveInfo
-  ): AsyncIterator<T>;
+  ): MaybePromise<AsyncIterator<T>> | MaybePromiseDeep<AsyncIterator<T>>;
 
   /**
    * Resolve method for the field


### PR DESCRIPTION
With this PR I'm adding the ability to return a promise in the `subscribe` function and should make it possible to return the entire `SubscriptionPayload` of Prisma.

I can also provide an example if you want...

Fixes #119 