### PR TITLE
Add scalar examplex (Upload, DateTime) for new users

### DIFF
--- a/docs/api-scalarType.md
+++ b/docs/api-scalarType.md
@@ -28,6 +28,24 @@ const DateScalar = scalarType({
 });
 ```
 
+## Example of Upload scalar
+
+```
+import { GraphQLUpload } from 'graphql-upload';
+
+export const Upload = GraphQLUpload;
+```
+
+## Example of DateTime scalar
+
+```
+import { GraphQLDate } from "graphql-iso-date";
+
+export const DateTime = GraphQLDate;
+```
+
+## Exposing scalar as method
+
 If you have an existing GraphQL scalar and you'd like to expose it as a method on the builder, call `asNexusMethod`:
 
 ```ts


### PR DESCRIPTION
When I started with Nexus I had to find how to declare Upload and DateTime. It should be defined in the docs. Feel free to update it as you want.