### PR TITLE
Fix inline functions for custom scalars

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1170,14 +1170,15 @@ export class SchemaBuilder {
   ) {
     // @ts-ignore
     block[methodName] = (fieldName: string, opts: any) => {
-      // @ts-ignore
-      const fieldConfig = {
+      let fieldConfig = {
         type: typeName,
-        ...opts
       }
 
       if (typeof opts === 'function') {
+        // @ts-ignore
         fieldConfig.resolve = opts
+      } else {
+        fieldConfig = { ...fieldConfig, ...opts}
       }
 
       // @ts-ignore

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1171,10 +1171,17 @@ export class SchemaBuilder {
     // @ts-ignore
     block[methodName] = (fieldName: string, opts: any) => {
       // @ts-ignore
-      block.field(fieldName, {
+      const fieldConfig = {
         type: typeName,
-        ...opts,
-      });
+        ...opts
+      }
+
+      if (typeof opts === 'function') {
+        fieldConfig['resolve'] = opts
+      }
+
+      // @ts-ignore
+      block.field(fieldName, fieldConfig);
     };
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1177,7 +1177,7 @@ export class SchemaBuilder {
       }
 
       if (typeof opts === 'function') {
-        fieldConfig['resolve'] = opts
+        fieldConfig.resolve = opts
       }
 
       // @ts-ignore

--- a/tests/resolveTypes.spec.ts
+++ b/tests/resolveTypes.spec.ts
@@ -1,6 +1,12 @@
 import { graphql } from 'graphql'
 import { makeSchema, queryType, scalarType } from "../src";
 
+interface Result {
+  data?: { 
+    testDate: Date; 
+  }
+}
+
 describe("custom scalars", () => {
   it("resolve custom scalar with inline functions", async () => {
     const now = new Date()
@@ -27,7 +33,7 @@ describe("custom scalars", () => {
         testDate
       }
     `
-    const { data: { testDate } } = await graphql(schema, query)
-    expect(testDate).toBe(now.getTime())
+    const result: Result  = await graphql(schema, query)
+    expect(result.data.testDate).toBe(now.getTime())
   });
 });

--- a/tests/resolveTypes.spec.ts
+++ b/tests/resolveTypes.spec.ts
@@ -34,6 +34,6 @@ describe("custom scalars", () => {
       }
     `
     const result: Result  = await graphql(schema, query)
-    expect(result.data.testDate).toBe(now.getTime())
+    expect(result.data!.testDate).toBe(now.getTime())
   });
 });

--- a/tests/resolveTypes.spec.ts
+++ b/tests/resolveTypes.spec.ts
@@ -1,0 +1,42 @@
+import { graphql } from 'graphql'
+import { makeSchema, queryType, scalarType } from "../src";
+
+describe("custom scalars", () => {
+  it("resolve custom scalar with inline functions", async () => {
+    const now = new Date()
+    const schema = makeSchema({
+      types: [
+        scalarType({
+          name: "Date",
+          asNexusMethod: "date",
+          description: "Date custom scalar type",
+          parseValue(value) {
+            return new Date(value);
+          },
+          serialize(value) {
+            return value.getTime();
+          },
+          parseLiteral(ast) {
+            if (ast.kind === Kind.INT) {
+              return new Date(ast.value);
+            }
+            return null;
+          },
+        }),
+        queryType({
+          definition(t) {
+          t.date('testDate', () => now)
+         }
+        })
+      ],
+      outputs: false,
+    });
+    const query = `
+      {
+        testDate
+      }
+    `
+    const { data: { testDate } } = await graphql(schema, query)
+    expect(testDate).toBe(now.getTime())
+  });
+});

--- a/tests/resolveTypes.spec.ts
+++ b/tests/resolveTypes.spec.ts
@@ -22,6 +22,7 @@ describe("custom scalars", () => {
         }),
         queryType({
           definition(t) {
+            // @ts-ignore 
             t.date('testDate', () => now)
           }
         })
@@ -33,7 +34,7 @@ describe("custom scalars", () => {
         testDate
       }
     `
-    const result: Result  = await graphql(schema, query)
+    const result: Result = await graphql(schema, query)
     expect(result.data!.testDate).toBe(now.getTime())
   });
 });

--- a/tests/resolveTypes.spec.ts
+++ b/tests/resolveTypes.spec.ts
@@ -8,25 +8,16 @@ describe("custom scalars", () => {
       types: [
         scalarType({
           name: "Date",
+          serialize: (value) => value.getTime(),
+          parseValue: (value) => new Date(value),
+          parseLiteral: (ast) => (ast.kind === "IntValue" ? new Date(ast.value) : null),
           asNexusMethod: "date",
-          description: "Date custom scalar type",
-          parseValue(value) {
-            return new Date(value);
-          },
-          serialize(value) {
-            return value.getTime();
-          },
-          parseLiteral(ast) {
-            if (ast.kind === Kind.INT) {
-              return new Date(ast.value);
-            }
-            return null;
-          },
+          rootTyping: "Date",
         }),
         queryType({
           definition(t) {
-          t.date('testDate', () => now)
-         }
+            t.date('testDate', () => now)
+          }
         })
       ],
       outputs: false,

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -18,7 +18,7 @@
         "sidebar_label": "enumType"
       },
       "api-extendType": {
-        "title": "extendType",
+        "title": "extendType / extendInputType",
         "sidebar_label": "extendType"
       },
       "api-inputObjectType": {
@@ -33,9 +33,17 @@
         "title": "makeSchema",
         "sidebar_label": "makeSchema"
       },
+      "api-mutationField": {
+        "title": "mutationField",
+        "sidebar_label": "mutationField"
+      },
       "api-objectType": {
         "title": "objectType",
         "sidebar_label": "objectType"
+      },
+      "api-queryField": {
+        "title": "queryField",
+        "sidebar_label": "queryField"
       },
       "api-scalarType": {
         "title": "scalarType",
@@ -49,9 +57,13 @@
         "title": "Best Practices",
         "sidebar_label": "Best Practices"
       },
+      "database-access-with-prisma-v2": {
+        "title": "Database Access with Prisma 2 (Preview)",
+        "sidebar_label": "Prisma 2 (Preview)"
+      },
       "database-access-with-prisma": {
         "title": "Database Access with Prisma",
-        "sidebar_label": "Database Access w/ Prisma"
+        "sidebar_label": "Prisma"
       },
       "future-features": {
         "title": "Potential Features",
@@ -83,7 +95,8 @@
     },
     "categories": {
       "Documentation": "Documentation",
-      "API": "API"
+      "API": "API",
+      "Plugins": "Plugins"
     }
   },
   "pages-strings": {


### PR DESCRIPTION
You can check the issue [here](https://nexus.js.org/playground).

```js
t.date('updatedAt', () => new Date());
``` 
is not working as expected, as it is right now it only works with:

```js
t.field('updatedAt', {
  type: 'Date',
  resolve: () => new Date()
});
```