### PR TITLE
fix: dynamic output property

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -374,6 +374,7 @@ export class SchemaBuilder {
       | GraphQLNamedType
       | DynamicInputMethodDef<string>
       | DynamicOutputMethodDef<string>
+      | DynamicOutputPropertyDef<string>
   ) {
     if (isNexusDynamicInputMethod(typeDef)) {
       this.dynamicInputFields[typeDef.name] = typeDef;
@@ -1362,7 +1363,8 @@ function addTypes(builder: SchemaBuilder, types: any) {
     isNexusExtendInputTypeDef(types) ||
     isNamedType(types) ||
     isNexusDynamicInputMethod(types) ||
-    isNexusDynamicOutputMethod(types)
+    isNexusDynamicOutputMethod(types) ||
+    isNexusDynamicOutputProperty(types)
   ) {
     builder.addType(types);
   } else if (Array.isArray(types)) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1149,17 +1149,15 @@ export class SchemaBuilder {
         return this.addDynamicScalar(methodName, val, block);
       }
       // @ts-ignore
-      Object.defineProperty(block, methodName, {
-        get() {
-          return val.value.factory({
-            args: [],
-            typeDef: block,
-            builder: this,
-            typeName: block.typeName,
-          })
-        },
-        enumerable: true,
-      })
+      block[methodName] = (...args: any[]) => {
+        const config = isList ? [args[0], { list: isList, ...args[1] }] : args;
+        return val.value.factory({
+          args: config,
+          typeDef: block,
+          builder: this,
+          typeName: block.typeName,
+        });
+      };
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1148,7 +1148,12 @@ export class SchemaBuilder {
       if (typeof val === "string") {
         return this.addDynamicScalar(methodName, val, block);
       }
-      // @ts-ignore
+
+      // At this point `methodName` identifier name can be a misnormer. If the
+      // given factory returns a function then methodName is accurate, but not
+      // if the factory returns something else. For example it may return an
+      // object of methods (aka. methods under a namespace/field/property)
+      // in which case a better identifier might be `namespace`, `propName`, ...
       Object.defineProperty(block, methodName, {
         get() {
           return val.value.factory({
@@ -1156,10 +1161,10 @@ export class SchemaBuilder {
             typeDef: block,
             builder: this,
             typeName: block.typeName,
-          })
+          });
         },
         enumerable: true,
-      })
+      });
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1149,15 +1149,17 @@ export class SchemaBuilder {
         return this.addDynamicScalar(methodName, val, block);
       }
       // @ts-ignore
-      block[methodName] = (...args: any[]) => {
-        const config = isList ? [args[0], { list: isList, ...args[1] }] : args;
-        return val.value.factory({
-          args: config,
-          typeDef: block,
-          builder: this,
-          typeName: block.typeName,
-        });
-      };
+      Object.defineProperty(block, methodName, {
+        get() {
+          return val.value.factory({
+            args: [],
+            typeDef: block,
+            builder: this,
+            typeName: block.typeName,
+          })
+        },
+        enumerable: true,
+      })
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -126,10 +126,7 @@ import {
   NexusExtendInputTypeConfig,
 } from "./definitions/extendInputType";
 import { DynamicInputMethodDef, DynamicOutputMethodDef } from "./dynamicMethod";
-import {
-  DynamicOutputPropertyDef,
-  DynamicInputPropertyDef,
-} from "./dynamicProperty";
+import { DynamicOutputPropertyDef } from "./dynamicProperty";
 
 export type Maybe<T> = T | null;
 
@@ -269,11 +266,6 @@ export type DynamicOutputProperties = Record<
   DynamicOutputPropertyDef<string>
 >;
 
-export type DynamicInputProperties = Record<
-  string,
-  DynamicInputPropertyDef<string>
->;
-
 /**
  * Builds all of the types, properly accounts for any using "mix".
  * Since the enum types are resolved synchronously, these need to guard for
@@ -332,11 +324,6 @@ export class SchemaBuilder {
    * Add dynamic output properties
    */
   protected dynamicOutputProperties: DynamicOutputProperties = {};
-
-  /**
-   * Add dynamic input properties
-   */
-  protected dynamicInputProperties: DynamicInputProperties = {};
 
   /**
    * All types that need to be traversed for children types
@@ -1156,27 +1143,18 @@ export class SchemaBuilder {
     return obj;
   }
 
-  // MARK
   addDynamicInputFields(block: InputDefinitionBlock<any>, isList: boolean) {
     eachObj(this.dynamicInputFields, (val, methodName) => {
       if (typeof val === "string") {
         return this.addDynamicScalar(methodName, val, block);
       }
 
-      // @ts-ignore
-      block[methodName] = (...args: any[]) => {
-        const config = isList ? [args[0], { list: isList, ...args[1] }] : args;
-        return val.value.factory({
-          args: config,
-          typeDef: block,
-          builder: this,
-          typeName: block.typeName,
-        });
-      };
-    });
-
-    eachObj(this.dynamicInputProperties, (val, propertyName) => {
-      Object.defineProperty(block, propertyName, {
+      // At this point `methodName` identifier name can be a misnormer. If the
+      // given factory returns a function then methodName is accurate, but not
+      // if the factory returns something else. For example it may return an
+      // object of methods (aka. methods under a namespace/field/property)
+      // in which case a better identifier might be `namespace`, `propName`, ...
+      Object.defineProperty(block, methodName, {
         get() {
           return val.value.factory({
             args: [],
@@ -1190,7 +1168,6 @@ export class SchemaBuilder {
     });
   }
 
-  // MARK
   addDynamicOutputMembers(block: OutputDefinitionBlock<any>, isList: boolean) {
     eachObj(this.dynamicOutputFields, (val, methodName) => {
       if (typeof val === "string") {
@@ -1221,7 +1198,6 @@ export class SchemaBuilder {
     });
   }
 
-  // MARK
   addDynamicScalar(
     methodName: string,
     typeName: string,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1148,12 +1148,7 @@ export class SchemaBuilder {
       if (typeof val === "string") {
         return this.addDynamicScalar(methodName, val, block);
       }
-
-      // At this point `methodName` identifier name can be a misnormer. If the
-      // given factory returns a function then methodName is accurate, but not
-      // if the factory returns something else. For example it may return an
-      // object of methods (aka. methods under a namespace/field/property)
-      // in which case a better identifier might be `namespace`, `propName`, ...
+      // @ts-ignore
       Object.defineProperty(block, methodName, {
         get() {
           return val.value.factory({
@@ -1161,10 +1156,10 @@ export class SchemaBuilder {
             typeDef: block,
             builder: this,
             typeName: block.typeName,
-          });
+          })
         },
         enumerable: true,
-      });
+      })
     });
   }
 

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -29,6 +29,7 @@ export enum NexusTypes {
   DynamicInput = "DynamicInput",
   DynamicOutputMethod = "DynamicOutputMethod",
   DynamicOutputProperty = "DynamicOutputProperty",
+  DynamicInputProperty = "DynamicInputProperty",
 }
 
 export interface DeprecationInfo {

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -29,7 +29,6 @@ export enum NexusTypes {
   DynamicInput = "DynamicInput",
   DynamicOutputMethod = "DynamicOutputMethod",
   DynamicOutputProperty = "DynamicOutputProperty",
-  DynamicInputProperty = "DynamicInputProperty",
 }
 
 export interface DeprecationInfo {

--- a/src/definitions/wrapping.ts
+++ b/src/definitions/wrapping.ts
@@ -148,7 +148,7 @@ export function isNexusDynamicOutputProperty<T extends string>(
 ): obj is DynamicOutputPropertyDef<T> {
   return (
     isNexusTypeDef(obj) &&
-    obj[NexusWrappedSymbol] === NexusTypes.DynamicOutputMethod
+    obj[NexusWrappedSymbol] === NexusTypes.DynamicOutputProperty
   );
 }
 export function isNexusDynamicOutputMethod<T extends string>(

--- a/src/dynamicProperty.ts
+++ b/src/dynamicProperty.ts
@@ -1,14 +1,7 @@
 import { withNexusSymbol, NexusTypes } from "./definitions/_types";
 import { BaseExtensionConfig } from "./dynamicMethod";
 import { SchemaBuilder } from "./builder";
-import {
-  OutputDefinitionBlock,
-  InputDefinitionBlock,
-} from "./definitions/definitionBlocks";
-
-//
-// Ouput
-//
+import { OutputDefinitionBlock } from "./definitions/definitionBlocks";
 
 export type OutputPropertyFactoryConfig<T> = {
   builder: SchemaBuilder;
@@ -49,40 +42,4 @@ export function dynamicOutputProperty<T extends string>(
   config: DynamicOutputPropertyConfig<T>
 ) {
   return new DynamicOutputPropertyDef(config.name, config);
-}
-
-//
-// Input
-//
-
-export type InputFactoryConfig<T> = {
-  args: any[];
-  builder: SchemaBuilder;
-  typeDef: InputDefinitionBlock<any>;
-  /**
-   * The name of the type this field is being declared on
-   */
-  typeName: string;
-};
-
-export type InputConfig<T extends string> = BaseExtensionConfig<T> & {
-  /**
-   * Invoked when the property is accessed (as a getter)
-   */
-  factory(config: InputFactoryConfig<T>): any;
-};
-
-export class DynamicInputPropertyDef<Name extends string> {
-  constructor(readonly name: Name, protected config: InputConfig<Name>) {}
-  get value() {
-    return this.config;
-  }
-}
-
-/**
- * Same as the outputFieldExtension, but for fields that
- * should be added on as input types.
- */
-export function dynamicInputProperty<T extends string>(config: InputConfig<T>) {
-  return new DynamicInputPropertyDef(config.name, config);
 }

--- a/src/dynamicProperty.ts
+++ b/src/dynamicProperty.ts
@@ -1,7 +1,14 @@
 import { withNexusSymbol, NexusTypes } from "./definitions/_types";
 import { BaseExtensionConfig } from "./dynamicMethod";
 import { SchemaBuilder } from "./builder";
-import { OutputDefinitionBlock } from "./definitions/definitionBlocks";
+import {
+  OutputDefinitionBlock,
+  InputDefinitionBlock,
+} from "./definitions/definitionBlocks";
+
+//
+// Ouput
+//
 
 export type OutputPropertyFactoryConfig<T> = {
   builder: SchemaBuilder;
@@ -42,4 +49,40 @@ export function dynamicOutputProperty<T extends string>(
   config: DynamicOutputPropertyConfig<T>
 ) {
   return new DynamicOutputPropertyDef(config.name, config);
+}
+
+//
+// Input
+//
+
+export type InputFactoryConfig<T> = {
+  args: any[];
+  builder: SchemaBuilder;
+  typeDef: InputDefinitionBlock<any>;
+  /**
+   * The name of the type this field is being declared on
+   */
+  typeName: string;
+};
+
+export type InputConfig<T extends string> = BaseExtensionConfig<T> & {
+  /**
+   * Invoked when the property is accessed (as a getter)
+   */
+  factory(config: InputFactoryConfig<T>): any;
+};
+
+export class DynamicInputPropertyDef<Name extends string> {
+  constructor(readonly name: Name, protected config: InputConfig<Name>) {}
+  get value() {
+    return this.config;
+  }
+}
+
+/**
+ * Same as the outputFieldExtension, but for fields that
+ * should be added on as input types.
+ */
+export function dynamicInputProperty<T extends string>(config: InputConfig<T>) {
+  return new DynamicInputPropertyDef(config.name, config);
 }

--- a/src/dynamicProperty.ts
+++ b/src/dynamicProperty.ts
@@ -29,7 +29,7 @@ export class DynamicOutputPropertyDef<Name extends string> {
     return this.config;
   }
 }
-withNexusSymbol(DynamicOutputPropertyDef, NexusTypes.DynamicOutputMethod);
+withNexusSymbol(DynamicOutputPropertyDef, NexusTypes.DynamicOutputProperty);
 
 /**
  * Defines a new property on the object definition block

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ export {
   FieldType,
 } from "./typegenTypeHelpers";
 export { dynamicInputMethod, dynamicOutputMethod } from "./dynamicMethod";
-export { dynamicInputProperty, dynamicOutputProperty } from "./dynamicProperty";
 export { core, blocks, ext };
 import * as core from "./core";
 import * as blocks from "./blocks";

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   FieldType,
 } from "./typegenTypeHelpers";
 export { dynamicInputMethod, dynamicOutputMethod } from "./dynamicMethod";
+export { dynamicInputProperty, dynamicOutputProperty } from "./dynamicProperty";
 export { core, blocks, ext };
 import * as core from "./core";
 import * as blocks from "./blocks";

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   FieldType,
 } from "./typegenTypeHelpers";
 export { dynamicInputMethod, dynamicOutputMethod } from "./dynamicMethod";
+export { dynamicOutputProperty } from "./dynamicProperty";
 export { core, blocks, ext };
 import * as core from "./core";
 import * as blocks from "./blocks";


### PR DESCRIPTION
This change addresses the last thing remaining in the way before `nexus-prisma` can get back on the nexus mainline.

https://github.com/prisma/nexus-prisma/issues/304