### PR TITLE
fix: typegen for dynamicOutputProperty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn lint
-      - run: yarn jest --ci
+      - run: yarn test:ci
 
 workflows:
   nexus:

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,13 +12,10 @@ module.exports = {
   globals: {
     "ts-jest": {
       isolatedModules: !process.env.CI,
-      tsConfig: {
+      diagnostics: {
         // FIXME: sloppy, can we make { core } not output in
         // typegen when its not needed?
-        noUnusedLocals: false,
-      },
-      diagnostics: {
-        warnOnly: !process.env.CI,
+        ignoreCodes: ["6133"],
       },
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,11 @@ module.exports = {
   globals: {
     "ts-jest": {
       isolatedModules: !process.env.CI,
+      tsConfig: {
+        // FIXME: sloppy, can we make { core } not output in
+        // typegen when its not needed?
+        noUnusedLocals: false,
+      },
       diagnostics: {
         warnOnly: !process.env.CI,
       },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^24",
     "jest-watch-typeahead": "^0.3.1",
     "lint-staged": "^7.3.0",
+    "nexus": "file:.",
     "prettier": "^1.16.0",
     "ts-jest": "^24",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "yarn link-examples && tsc -w",
     "test": "jest",
-    "test:ci": "jest -i",
+    "test:ci": "yarn add file:. && jest -i",
     "build": "tsc",
     "lint": "tslint -p tsconfig.json",
     "clean": "rm -rf dist",

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -144,7 +144,8 @@ export interface InputDefinitionBuilder {
 }
 
 export interface OutputDefinitionBlock<TypeName extends string>
-  extends NexusGenCustomOutputMethods<TypeName> {}
+  extends NexusGenCustomOutputMethods<TypeName>,
+    NexusGenCustomOutputProperties<TypeName> {}
 
 /**
  * The output definition block is passed to the "definition"

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -104,6 +104,7 @@ export class Typegen {
       this.printDynamicImport(),
       this.printDynamicInputFieldDefinitions(),
       this.printDynamicOutputFieldDefinitions(),
+      this.printDynamicOutputPropertyDefinitions(),
       GLOBAL_DECLARATION,
     ].join("\n");
   }
@@ -213,6 +214,25 @@ export class Typegen {
           }
           return `    ${key}${val.value.typeDefinition ||
             `(...args: any): void`}`;
+        })
+      )
+      .concat([`  }`, `}`])
+      .join("\n");
+  }
+
+  printDynamicOutputPropertyDefinitions() {
+    const { dynamicOutputProperties } = this.extensions.dynamicFields;
+    // If there is nothing custom... exit
+    if (!Object.keys(dynamicOutputProperties).length) {
+      return [];
+    }
+    return [
+      `declare global {`,
+      `  interface NexusGenCustomOutputProperties<TypeName extends string> {`,
+    ]
+      .concat(
+        mapObj(dynamicOutputProperties, (val, key) => {
+          return `    ${key}${val.value.typeDefinition || `: any`}`;
         })
       )
       .concat([`  }`, `}`])

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -4,6 +4,7 @@ declare global {
   interface NexusGen {}
   interface NexusGenCustomInputMethods<TypeName extends string> {}
   interface NexusGenCustomOutputMethods<TypeName extends string> {}
+  interface NexusGenCustomOutputProperties<TypeName extends string> {}
 }
 
 export type AllInputTypes = GetGen<"allInputTypes", string>;

--- a/tests/__snapshots__/backingTypes.spec.ts.snap
+++ b/tests/__snapshots__/backingTypes.spec.ts.snap
@@ -11,6 +11,7 @@ import { TestEnum } from \\"./tests/backingTypes.spec\\"
 
 
 
+
 declare global {
   interface NexusGen extends NexusGenTypes {}
 }

--- a/tests/__snapshots__/typegen.spec.ts.snap
+++ b/tests/__snapshots__/typegen.spec.ts.snap
@@ -153,6 +153,7 @@ import * as t from \\"./_helpers\\"
 
 
 
+
 declare global {
   interface NexusGen extends NexusGenTypes {}
 }

--- a/tests/integration/_s.ts
+++ b/tests/integration/_s.ts
@@ -17,31 +17,31 @@ const mockData = {
   user: { firstName: "", lastName: "" },
 };
 
-export const d1 = dynamicOutputMethod({
-  name: "d1",
+export const dom = dynamicOutputMethod({
+  name: "title",
   factory: ({ typeDef: t }) => {
-    t.boolean("boolViaDynamic");
+    t.string("title");
   },
 });
 
-export const d2 = dynamicInputMethod({
-  name: "d2",
+export const dim = dynamicInputMethod({
+  name: "title",
   factory: ({ typeDef: t }) => {
-    t.boolean("boolViaDynamic");
+    t.string("title", { nullable: true });
   },
 });
 
-export const d3 = dynamicOutputProperty({
-  name: "d3",
+export const dop = dynamicOutputProperty({
+  name: "body",
   factory: ({ typeDef: t }) => {
-    t.boolean("boolViaDynamic");
+    t.string("body");
   },
 });
 
 export const PostSearchInput = inputObjectType({
   name: "PostSearchInput",
   definition(t) {
-    t.string("title", { nullable: true });
+    t.title();
     t.string("body", { nullable: true });
   },
 });
@@ -49,8 +49,9 @@ export const PostSearchInput = inputObjectType({
 export const Post = objectType({
   name: "Post",
   definition(t) {
-    t.string("title");
-    t.string("body");
+    t.title();
+    // tslint:disable-next-line: no-unused-expression
+    t.body;
   },
 });
 
@@ -59,7 +60,6 @@ export const User = objectType({
   definition(t) {
     t.string("firstName");
     t.string("lastName");
-    // t.test()
   },
 });
 

--- a/tests/integration/_s.ts
+++ b/tests/integration/_s.ts
@@ -7,6 +7,8 @@ import {
   inputObjectType,
   extendType,
   dynamicOutputMethod,
+  dynamicInputMethod,
+  dynamicOutputProperty,
 } from "../../src";
 export * from "./_xs";
 
@@ -15,10 +17,24 @@ const mockData = {
   user: { firstName: "", lastName: "" },
 };
 
-dynamicOutputMethod({
-  name: "test",
-  factory: ({ typeDef }) => {
-    typeDef.boolean("boolViaDynamic");
+export const d1 = dynamicOutputMethod({
+  name: "d1",
+  factory: ({ typeDef: t }) => {
+    t.boolean("boolViaDynamic");
+  },
+});
+
+export const d2 = dynamicOutputMethod({
+  name: "d2",
+  factory: ({ typeDef: t }) => {
+    t.boolean("boolViaDynamic");
+  },
+});
+
+export const d3 = dynamicOutputMethod({
+  name: "d3",
+  factory: ({ typeDef: t }) => {
+    t.boolean("boolViaDynamic");
   },
 });
 

--- a/tests/integration/_s.ts
+++ b/tests/integration/_s.ts
@@ -24,14 +24,14 @@ export const d1 = dynamicOutputMethod({
   },
 });
 
-export const d2 = dynamicOutputMethod({
+export const d2 = dynamicInputMethod({
   name: "d2",
   factory: ({ typeDef: t }) => {
     t.boolean("boolViaDynamic");
   },
 });
 
-export const d3 = dynamicOutputMethod({
+export const d3 = dynamicOutputProperty({
   name: "d3",
   factory: ({ typeDef: t }) => {
     t.boolean("boolViaDynamic");

--- a/tests/integration/_s.ts
+++ b/tests/integration/_s.ts
@@ -6,6 +6,7 @@ import {
   stringArg,
   inputObjectType,
   extendType,
+  dynamicOutputMethod,
 } from "../../src";
 export * from "./_xs";
 
@@ -13,6 +14,13 @@ const mockData = {
   posts: [{ title: "", body: "" }],
   user: { firstName: "", lastName: "" },
 };
+
+dynamicOutputMethod({
+  name: "test",
+  factory: ({ typeDef }) => {
+    typeDef.boolean("boolViaDynamic");
+  },
+});
 
 export const PostSearchInput = inputObjectType({
   name: "PostSearchInput",
@@ -35,6 +43,7 @@ export const User = objectType({
   definition(t) {
     t.string("firstName");
     t.string("lastName");
+    // t.test()
   },
 });
 

--- a/tests/integration/_s.typegen.ts
+++ b/tests/integration/_s.typegen.ts
@@ -7,12 +7,17 @@
 import { core } from "nexus"
 declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
-    d2(...args: any): void
+    title(...args: any): void
   }
 }
 declare global {
   interface NexusGenCustomOutputMethods<TypeName extends string> {
-    d1(...args: any): void
+    title(...args: any): void
+  }
+}
+declare global {
+  interface NexusGenCustomOutputProperties<TypeName extends string> {
+    body: any
   }
 }
 

--- a/tests/integration/_s.typegen.ts
+++ b/tests/integration/_s.typegen.ts
@@ -4,9 +4,17 @@
  */
 
 
-
-
-
+import { core } from "nexus"
+declare global {
+  interface NexusGenCustomInputMethods<TypeName extends string> {
+    d2(...args: any): void
+  }
+}
+declare global {
+  interface NexusGenCustomOutputMethods<TypeName extends string> {
+    d1(...args: any): void
+  }
+}
 
 declare global {
   interface NexusGen extends NexusGenTypes {}

--- a/tests/integration/_xs.typegen.ts
+++ b/tests/integration/_xs.typegen.ts
@@ -8,6 +8,7 @@
 
 
 
+
 declare global {
   interface NexusGen extends NexusGenTypes {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,11 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+"nexus@file:.":
+  version "0.12.0-beta.7"
+  dependencies:
+    tslib "^1.9.3"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,6 +2777,11 @@ neo-async@^2.6.0:
   dependencies:
     tslib "^1.9.3"
 
+"nexus@file:./.":
+  version "0.12.0-beta.7"
+  dependencies:
+    tslib "^1.9.3"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"


### PR DESCRIPTION
- [x] cover dynamicOutputMethod in integration test
- [x] cover dynamicOutputProperty  in integration test
- [x] cover dynamicInputMethod in integration test
- [x] typegen for `dynamicOutputProperty`

https://github.com/prisma/nexus-prisma/issues/367#issuecomment-526882555

Will fix prisma/nexus-prisma#367
Will unblock https://github.com/prisma/nexus-prisma/pull/368