### PR TITLE
Correct error message about absolute paths

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export const isObject = (obj: any): boolean =>
 export const assertAbsolutePath = (pathName: string, property: string) => {
   if (!path.isAbsolute(pathName)) {
     throw new Error(
-      `Expected path for ${property} to be a string, saw ${pathName}`
+      `Expected path for ${property} to be an absolute path, saw ${pathName}`
     );
   }
   return pathName;


### PR DESCRIPTION
The absolute path error was driving me nuts, as I thought it was telling me my string was not a string. I've updated the error message to correctly communicate the error.